### PR TITLE
Update yard.rb

### DIFF
--- a/lib/hoe/yard.rb
+++ b/lib/hoe/yard.rb
@@ -49,8 +49,8 @@ module Hoe::Yard
     self.yard_options = []
 
     # find the README.* and History.* files
-    self.readme_file = intuit_file_name(File.basename(self.readme_file))
-    self.history_file = intuit_file_name(File.basename(self.history_file))
+    self.readme_file ||= intuit_file_name(File.basename(self.readme_file))
+    self.history_file ||= intuit_file_name(File.basename(self.history_file))
 
     # disable RDoc and ri tasks
     self.need_rdoc = false


### PR DESCRIPTION
If the Manifest.txt file already has a README.ext  and a History.ext then use the values.  Also, if you define your spec like
MyGem.spec do
self.readme_file = 'readme_only.txt'
self.history_file = 'historyiscool.txt'
end

you want that to work.

Also, could you release a new gem with these additions?

thanks
